### PR TITLE
Fixed deprecation messages with apcu

### DIFF
--- a/scripts/v3.12/php-8.1/php8-apcu/APKBUILD
+++ b/scripts/v3.12/php-8.1/php8-apcu/APKBUILD
@@ -4,7 +4,7 @@ pkgname=php8-apcu
 srcdir="/tmp/src-$pkgname"
 pkgbasedir="/tmp/pkg-$pkgname"
 _pkgreal=apcu
-pkgver=5.1.19
+pkgver=5.1.21
 pkgrel=1
 _phpver=8
 provides="php-apcu=8.1"
@@ -37,4 +37,4 @@ package() {
     echo "extension=$_pkgreal" > "$pkgdir"/etc/php$_phpver/conf.d/00_$_pkgreal.ini || return 1
 }
 
-sha512sums="45077e3bd0eac207539e2eafe21968c71f49b8c8920168dbafa87961b041f1d348b6bf1c130104744bc541e1f690854f0a29062e9520db81c04edeee3ef2ed99  apcu-5.1.19.tgz"
+sha512sums="a6ffe8349760d27cde0d86017a59a68e9639bf385e606622d807094f4e5fb305bb25b9ce00077d0856f4d223d44329f7a6314c229b62c78d8e2b085593c92bb3  apcu-5.1.21.tgz"

--- a/scripts/v3.13/php-8.1/php8-apcu/APKBUILD
+++ b/scripts/v3.13/php-8.1/php8-apcu/APKBUILD
@@ -4,7 +4,7 @@ pkgname=php8-apcu
 srcdir="/tmp/src-$pkgname"
 pkgbasedir="/tmp/pkg-$pkgname"
 _pkgreal=apcu
-pkgver=5.1.19
+pkgver=5.1.21
 pkgrel=1
 _phpver=8
 provides="php-apcu=8.1"
@@ -37,4 +37,4 @@ package() {
     echo "extension=$_pkgreal" > "$pkgdir"/etc/php$_phpver/conf.d/00_$_pkgreal.ini || return 1
 }
 
-sha512sums="45077e3bd0eac207539e2eafe21968c71f49b8c8920168dbafa87961b041f1d348b6bf1c130104744bc541e1f690854f0a29062e9520db81c04edeee3ef2ed99  apcu-5.1.19.tgz"
+sha512sums="a6ffe8349760d27cde0d86017a59a68e9639bf385e606622d807094f4e5fb305bb25b9ce00077d0856f4d223d44329f7a6314c229b62c78d8e2b085593c92bb3  apcu-5.1.21.tgz"

--- a/scripts/v3.14/php-8.1/php8-apcu/APKBUILD
+++ b/scripts/v3.14/php-8.1/php8-apcu/APKBUILD
@@ -4,7 +4,7 @@ pkgname=php8-apcu
 srcdir="/tmp/src-$pkgname"
 pkgbasedir="/tmp/pkg-$pkgname"
 _pkgreal=apcu
-pkgver=5.1.19
+pkgver=5.1.21
 pkgrel=1
 _phpver=8
 provides="php-apcu=8.1"
@@ -38,5 +38,5 @@ package() {
 }
 
 sha512sums="
-45077e3bd0eac207539e2eafe21968c71f49b8c8920168dbafa87961b041f1d348b6bf1c130104744bc541e1f690854f0a29062e9520db81c04edeee3ef2ed99  apcu-5.1.19.tgz
+a6ffe8349760d27cde0d86017a59a68e9639bf385e606622d807094f4e5fb305bb25b9ce00077d0856f4d223d44329f7a6314c229b62c78d8e2b085593c92bb3  apcu-5.1.21.tgz
 "


### PR DESCRIPTION
# Description
bumped apcu to 5.1.21 to fix deprecation messages

# Fixes
```
PHP Deprecated:  Return type of APCUIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
PHP Deprecated:  Return type of APCUIterator::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
PHP Deprecated:  Return type of APCUIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
PHP Deprecated:  Return type of APCUIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
PHP Deprecated:  Return type of APCUIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0
```

see https://github.com/krakjoe/apcu/issues/425