### PR TITLE
Missing core ext for php 8.1

### DIFF
--- a/scripts/v3.12/php-8.1/php8/APKBUILD
+++ b/scripts/v3.12/php-8.1/php8/APKBUILD
@@ -42,10 +42,10 @@ source="$_pkgreal-$pkgver.tar.bz2::http://br2.php.net/get/$_pkgreal-$pkgver.tar.
 	"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
-_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ftp gd gettext gmp iconv imap intl
+_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ffi fileinfo ftp gd gettext gmp iconv imap intl
 	ldap mbstring mysqli mysqlnd odbc opcache openssl pcntl pdo pdo_dblib pdo_mysql
-	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop snmp soap
-	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy xml xmlreader xsl zip zlib
+	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop simplexml snmp soap
+	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy tokenizer xml xmlreader xmlwriter xsl zip zlib
 	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg $pkgname-embed
 	$pkgname-litespeed $pkgname-cgi $pkgname-fpm $pkgname-pear::noarch

--- a/scripts/v3.13/php-8.1/php8/APKBUILD
+++ b/scripts/v3.13/php-8.1/php8/APKBUILD
@@ -42,10 +42,10 @@ source="$_pkgreal-$pkgver.tar.bz2::http://br2.php.net/get/$_pkgreal-$pkgver.tar.
 	"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
-_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ftp gd gettext gmp iconv imap intl
+_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ffi fileinfo ftp gd gettext gmp iconv imap intl
 	ldap mbstring mysqli mysqlnd odbc opcache openssl pcntl pdo pdo_dblib pdo_mysql
-	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop snmp soap
-	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy xml xmlreader xsl zip zlib
+	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop simplexml snmp soap
+	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy tokenizer xml xmlreader xmlwriter xsl zip zlib
 	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg $pkgname-embed
 	$pkgname-litespeed $pkgname-cgi $pkgname-fpm $pkgname-pear::noarch

--- a/scripts/v3.14/php-8.1/php8/APKBUILD
+++ b/scripts/v3.14/php-8.1/php8/APKBUILD
@@ -42,10 +42,10 @@ source="$_pkgreal-$pkgver.tar.bz2::http://br2.php.net/get/$_pkgreal-$pkgver.tar.
 	"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
-_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ftp gd gettext gmp iconv imap intl
+_exts="bcmath bz2 calendar ctype curl dba dom enchant exif ffi fileinfo ftp gd gettext gmp iconv imap intl
 	ldap mbstring mysqli mysqlnd odbc opcache openssl pcntl pdo pdo_dblib pdo_mysql
-	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop snmp soap
-	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy xml xmlreader xsl zip zlib
+	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop simplexml snmp soap
+	sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy tokenizer xml xmlreader xmlwriter xsl zip zlib
 	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg $pkgname-embed
 	$pkgname-litespeed $pkgname-cgi $pkgname-fpm $pkgname-pear::noarch


### PR DESCRIPTION
added missing core extensions to php 8.1 builds (ffi, fileinfo, simplexml, tokenizer, xmlwriter)

fixes https://github.com/codecasts/php-alpine/issues/155